### PR TITLE
Optimize project fetching and improve feedback on errors and delays

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,10 +57,11 @@ const inputs = [
 readSequential(inputs)
     .then(options => {
         return getCertificate(options).then(certs => {
+            if(!certs) return Promise.reject("Could not get certs. Check previous errors");
             console.log(`\nSuccess! Go to https://gitlab.com/${options.repository}/pages and create/update a domain with the following settings:\n`);
             console.log(`Domain: ${options.domain}\n`);
             console.log(`Certificate (PEM):\n${certs.cert}\n`);
             console.log(`Key (PEM):\n${certs.key}`);
         });
     })
-    .catch(err => console.error(err.detail || ''));
+    .catch(err => console.error(err.detail || err.message || 'There was an error executing. Aborting'));

--- a/index.js
+++ b/index.js
@@ -57,11 +57,10 @@ const inputs = [
 readSequential(inputs)
     .then(options => {
         return getCertificate(options).then(certs => {
-            if(!certs) return Promise.reject("Could not get certs. Check previous errors");
             console.log(`\nSuccess! Go to https://gitlab.com/${options.repository}/pages and create/update a domain with the following settings:\n`);
             console.log(`Domain: ${options.domain}\n`);
             console.log(`Certificate (PEM):\n${certs.cert}\n`);
             console.log(`Key (PEM):\n${certs.key}`);
         });
     })
-    .catch(err => console.error(err.detail || err.message || 'There was an error executing. Aborting'));
+    .catch(err => console.error(err.detail || err.message || err));

--- a/lib.js
+++ b/lib.js
@@ -79,10 +79,8 @@ module.exports = (options) => {
             }
         }));
     };
-    console.log("Starting...this can take a couple of minutes");
     return Promise.join(getUrls, generateRsa(), generateRsa(), getRepository(options.repository),
         (urls, accountKp, domainKp, repo) => {
-            console.log("Preparations ready, contacting let's encrypt and uploading challenge");
             return LeCore.registerNewAccountAsync({
                 newRegUrl: urls.newReg,
                 email: options.email,

--- a/lib.js
+++ b/lib.js
@@ -52,10 +52,7 @@ module.exports = (options) => {
 
     const getRepository = (name) => {
         return gitlabRequest.get({
-            url: '/projects'
-        }).then(projects => {
-            return projects.find(p => p.path_with_namespace === name)
-                || Promise.reject(`Could not find repository ${name}`);
+            url: `/projects/${name.replace('/','%2F')}`
         });
     };
 

--- a/lib.js
+++ b/lib.js
@@ -79,9 +79,10 @@ module.exports = (options) => {
             }
         }));
     };
-
+    console.log("Starting...this can take a couple of minutes");
     return Promise.join(getUrls, generateRsa(), generateRsa(), getRepository(options.repository),
         (urls, accountKp, domainKp, repo) => {
+            console.log("Preparations ready, contacting let's encrypt and uploading challenge");
             return LeCore.registerNewAccountAsync({
                 newRegUrl: urls.newReg,
                 email: options.email,

--- a/lib.js
+++ b/lib.js
@@ -107,7 +107,5 @@ module.exports = (options) => {
                     }
                 });
             });
-        }).catch((error)=> {
-          console.error(`ERROR: ${error.detail || error.message || JSON.stringify(error)}`);
         });
 };

--- a/lib.js
+++ b/lib.js
@@ -108,5 +108,7 @@ module.exports = (options) => {
                     }
                 });
             });
+        }).catch((error)=> {
+          console.error(`ERROR: ${error.detail || error.message || JSON.stringify(error)}`);
         });
 };


### PR DESCRIPTION
I'm submitting this PR  Regarding #6 to correct the following problems:
- To get the GitLab project, the app was using the project list API resource and then filtering. This is both inefficient and error-prone given there is an alternative to get only one project and that the resource used was paginating results to 20 projects per page and there was no simple way to get all projects at once. This lead to the issue #6
- ~~There was no feedback for a minute or so after the app was initiated (generating rsa keys) which lead to believe that it was hung.~~ This part has been removed from this PR as requested by @rolodato 
- There was no error message printed if the project was not being found. This was a tricky one given how Promise.join works, but nothing out of the realm of possibility
