### PR TITLE
Add support for validating multiple domains at once

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,10 +21,10 @@ Any omitted parameters will be prompted for interactively:
 
 ```sh
 gitlab-le \
---email      example@example.com     `# Let's Encrypt email address` \
---domain     example.com             `# Domain that the cert will be issued for` \
---repository gitlab_user/gitlab_repo `# Namespaced repository identifier` \
---token      ...                     `# GitLab personal access token, see https://gitlab.com/profile/personal_access_tokens`
+--email      example@example.com         `# Let's Encrypt email address` \
+--domain     example.com www.example.com `# Domain(s) that the cert will be issued for (separated by spaces)` \
+--repository gitlab_user/gitlab_repo     `# Namespaced repository identifier` \
+--token      ...                         `# GitLab personal access token, see https://gitlab.com/profile/personal_access_tokens`
 ```
 
 ## Example
@@ -32,16 +32,16 @@ gitlab-le \
 <details>
 <summary>Expand this section for example usage and output.</summary>
 ```
-$ gitlab-le --email rolodato@example.com --repository example/example.gitlab.io --token ... --domain example.com
+$ gitlab-le --email rolodato@example.com --repository example/example.gitlab.io --token ... --domain example.com www.example.com
 By using Let's Encrypt, you are agreeing to the TOS at https://letsencrypt.org/documents/LE-SA-v1.0.1-July-27-2015.pdf
 Uploaded challenge file, waiting for it to be available at http://example.com/.well-known/acme-challenge/lLqa_7sLPQzz102c2KIc3pqMevUyM_Ru92whx6w1C-4
 Could not find challenge file. Retrying in 15s...
 Could not find challenge file. Retrying in 30s...
 Could not find challenge file. Retrying in 1m...
 
-Success! Go to https://gitlab.com/example/example.gitlab.io/pages and create/update a domain with the following settings:
+Success! Go to https://gitlab.com/example/example.gitlab.io/pages and create/re-create domain(s) with the following settings:
 
-Domain: example.com
+Domain(s): example.com, www.example.com
 
 Certificate (PEM):
 -----BEGIN CERTIFICATE-----

--- a/index.js
+++ b/index.js
@@ -2,23 +2,29 @@
 
 const Promise = require('bluebird');
 const readInput = Promise.promisify(require('read'));
-const argv = require('yargs').argv;
+const argv = require('yargs').array('domain').argv;
 const xtend = require('xtend');
 const getCertificate = require('./lib.js');
 
-const read = (options) => () => {
+const read = (options) => (forceReadInput = false) => {
     const validator = options.validator ? options.validator : v => v && v.length > 0;
-    const argument = typeof argv[options.argument] === 'string' ? argv[options.argument] : undefined;
-    const resultPromise = argument ? Promise.resolve(argument) : readInput(options);
-    return resultPromise.then(value => {
-        if (validator(value)) {
+    const processValue = options.processValue ? options.processValue : v => v;
+    const resultPromise = forceReadInput ? readInput(options) : Promise.resolve(argv[options.argument]);
+    return resultPromise
+        .then(processValue)
+        .then(value => {
+            if (validator(value)) {
+                return value;
+            }
+
+            throw new Error();
+        })
+        .then(value => {
             var result = {};
             result[options.argument] = value;
             return result;
-        } else {
-            return read(options)();
-        }
-    });
+        })
+        .catch(() => read(options)(true));
 };
 
 const reduceSequential = (reducer, initialValue, accum = initialValue) => (promiseFns) => {
@@ -40,8 +46,10 @@ const inputs = [
         validator: v => v.match(/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i)
     }),
     read({
-        prompt: 'Domain that the cert will be issued for, e.g. example.com:',
-        argument: 'domain'
+        prompt: 'Domain(s) that the cert will be issued for (separated by spaces), e.g. example.com www.example.com foo.example.com:',
+        argument: 'domain',
+        processValue: v => v === undefined || Array.isArray(v) ? v : v.trim().split(/\s+/),
+        validator: v => v !== undefined && v.length > 0 && v.every(item => typeof item === 'string' && item.length > 0)
     }),
     read({
         prompt: 'GitLab pages repository identifier, e.g. foo/example.gitlab.io:',
@@ -57,8 +65,8 @@ const inputs = [
 readSequential(inputs)
     .then(options => {
         return getCertificate(options).then(certs => {
-            console.log(`\nSuccess! Go to https://gitlab.com/${options.repository}/pages and create/update a domain with the following settings:\n`);
-            console.log(`Domain: ${options.domain}\n`);
+            console.log(`\nSuccess! Go to https://gitlab.com/${options.repository}/pages and create/re-create domain(s) with the following settings:\n`);
+            console.log(`Domain(s): ${options.domain.join(', ')}\n`);
             console.log(`Certificate (PEM):\n${certs.cert}\n${certs.ca}\n`);
             console.log(`Key (PEM):\n${certs.key}`);
         });

--- a/lib.js
+++ b/lib.js
@@ -48,7 +48,7 @@ module.exports = (options) => {
             body: {
                 file_path: `public/.well-known/acme-challenge/${key}`,
                 commit_message: 'Automated Let\'s Encrypt renewal',
-                branch_name: 'master',
+                branch_name: repo.default_branch,
                 content: value
             }
         })).return([`http://${domain}/.well-known/acme-challenge/${key}`, value]);
@@ -60,7 +60,7 @@ module.exports = (options) => {
             body: {
                 file_path: `public/.well-known/acme-challenge/${key}`,
                 commit_message: 'Automated Let\'s Encrypt renewal',
-                branch_name: 'master'
+                branch_name: repo.default_branch
             }
         }));
     };

--- a/lib.js
+++ b/lib.js
@@ -56,7 +56,7 @@ module.exports = (options) => {
 
     const deleteChallenges = (key, repo) => {
         return Promise.resolve(gitlabRequest.delete({
-            url: `projects/${repo.id}/repository/files`,
+            url: `/projects/${repo.id}/repository/files`,
             body: {
                 file_path: `public/.well-known/acme-challenge/${key}`,
                 commit_message: 'Automated Let\'s Encrypt renewal',

--- a/lib.js
+++ b/lib.js
@@ -1,13 +1,12 @@
 'use strict';
 const Promise = require('bluebird');
-const LeTinyCore = require('letiny-core');
-const LeCore = Promise.promisifyAll(LeTinyCore);
-const LeCrypto = Promise.promisifyAll(LeCore.leCrypto);
+const ACME = Promise.promisifyAll(require('le-acme-core').ACME.create());
+const RSA = Promise.promisifyAll(require('rsa-compat').RSA);
 const ms = require('ms');
 const request = require('request-promise');
 
-const getUrls = LeCore.getAcmeUrlsAsync(LeCore.productionServerUrl);
-const generateRsa = () => LeCrypto.generateRsaKeypairAsync(2048, 65537);
+const getUrls = ACME.getAcmeUrlsAsync(ACME.productionServerUrl);
+const generateRsa = () => RSA.generateKeypairAsync(2048, 65537, {});
 
 const pollUntilDeployed = (url, expectedContent, timeoutMs = 15 * 1000, retries = 10) => {
     if (retries > 0) {
@@ -66,20 +65,20 @@ module.exports = (options) => {
     };
     return Promise.join(getUrls, generateRsa(), generateRsa(), getRepository(options.repository),
         (urls, accountKp, domainKp, repo) => {
-            return LeCore.registerNewAccountAsync({
+            return ACME.registerNewAccountAsync({
                 newRegUrl: urls.newReg,
                 email: options.email,
-                accountPrivateKeyPem: accountKp.privateKeyPem,
+                accountKeypair: accountKp,
                 agreeToTerms: (tosUrl, cb) => {
                     console.log(`By using Let's Encrypt, you are agreeing to the TOS at ${tosUrl}`);
                     cb(null, true);
                 }
             }).then(() => {
-                return LeCore.getCertificateAsync({
+                return ACME.getCertificateAsync({
                     newAuthzUrl: urls.newAuthz,
                     newCertUrl: urls.newCert,
-                    domainPrivateKeyPem: domainKp.privateKeyPem,
-                    accountPrivateKeyPem: accountKp.privateKeyPem,
+                    domainKeypair: domainKp,
+                    accountKeypair: accountKp,
                     domains: [options.domain],
                     setChallenge: (hostname, key, value, cb) => {
                         return uploadChallenge(key, value, repo, options.domain)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "bluebird": "3.4.1",
-    "letiny-core": "1.0.5",
+    "le-acme-core": "^2.0.9",
     "ms": "0.7.1",
     "read": "1.0.7",
     "request": "2.81.0",


### PR DESCRIPTION
This PR fixes #13 

I've also changed a dependency (`letiny-core` to `le-acme-core`) because there were warnings/errors during startup like:

```
This Let's Encrypt / ACME server has been updated with urls that this client doesn't understand
```

They're all gone now.