### PR TITLE
Fix Jekyll Issues

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -49,7 +49,7 @@ module.exports = (options) => {
 
     const uploadChallenge = (key, value, repo, domain) => {
         const challengeContent = options.jekyll ?
-                `---\nlayout: null\npermalink: /.well-known/acme-challenge/${key}\n---\n${value}` : value;
+                `---\nlayout: null\npermalink: /.well-known/acme-challenge/${key}/\n---\n${value}` : value;
         // Need to bluebird-ify to use .asCallback()
         const filePath = encodeURIComponent(path.posix.resolve('/', options.path, key));
         return Promise.resolve(gitlabRequest.post({

--- a/lib.js
+++ b/lib.js
@@ -51,7 +51,7 @@ module.exports = (options) => {
         const challengeContent = options.jekyll ?
                 `---\nlayout: null\npermalink: /.well-known/acme-challenge/${key}/\n---\n${value}` : value;
         // Need to bluebird-ify to use .asCallback()
-        const filePath = encodeURIComponent(path.posix.resolve('/', options.path, key));
+        const filePath = options.jekyll ? "letsencrypt.html" : encodeURIComponent(path.posix.resolve('/', options.path, key));
         return Promise.resolve(gitlabRequest.post({
             url: `/projects/${repo.id}/repository/files/${filePath}`,
             body: {
@@ -64,7 +64,7 @@ module.exports = (options) => {
     };
 
     const deleteChallenges = (key, repo) => {
-        const filePath = encodeURIComponent(path.posix.resolve('/', options.path, key));
+        const filePath = options.jekyll ? "letsencrypt.html" : encodeURIComponent(path.posix.resolve('/', options.path, key));
         return Promise.resolve(gitlabRequest.delete({
             url: `/projects/${repo.id}/repository/files/${filePath}`,
             body: {


### PR DESCRIPTION
This PR fixes a couple issues with the --jekyll flag.

1. Adds a trailing slash to the permalink. This is required due to [gitlab-pages issue #9](https://gitlab.com/gitlab-org/gitlab-pages/issues/9)
2. Changes the filePath to `/letsencrypt.html`.  This helps because:
  a. Jekyll doesn't by default render any pages in hidden directories (e.g. the default `/.well-known/ dir)
  b. Jekyll gets confused if the target file doesn't have an extension.  By adding a .html extension on the filePath it can properly serve it.  
