### PR TITLE
add option for branch

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -22,6 +22,7 @@ gitlab-le \
 --production                                            `# OPTIONAL - Obtain a real certificate instead of a dummy one and configure your repository to use it`
 --path                                                  `# OPTIONAL - Absolute path in your repository where challenge files should be uploaded`
 --jekyll                                                `# OPTIONAL - Upload challenge files with a Jekyll-compatible YAML front matter` \
+--branch                                                `# OPTIONAL - Upload challenge files to this branch, default is the main branch of the repository` \
 ```
 
 See `gitlab-le --help` for more details.

--- a/args.js
+++ b/args.js
@@ -34,11 +34,15 @@ module.exports = yargs
         describe: 'Obtain a real certificate instead of a dummy one and configure your repository to use it',
         type: 'boolean',
         default: false
+    }).option('branch', {
+        describe: 'Select the branch where the challenge files should be uploaded.',
+        type: 'string',
+        default: ''
     }).example('$0 --domain example.com www.example.com --email rolodato@example.com --repository https://gitlab.com/foo/example.gitlab.io --token abc123', 'Simple build where all files are served from public/ inside your repository')
     .example('$0 --jekyll --path / --domain example.com --email rolodato@example.com --repository https://gitlab.example.com/foo/myrepo --token abc123', 'Jekyll website that serves all valid files in your repository\'s root directory')
     .wrap(yargs.terminalWidth())
     .check(argv => {
-        const empty = Object.keys(argv).filter(key => key !== '_' && argv[key].length == 0);
+        const empty = Object.keys(argv).filter(key => key !== '_' && key !== 'branch' && argv[key].length == 0);
         if (empty.length > 0) {
             console.error(`Missing required arguments: ${empty.join(', ')}`);
             process.exit(1);


### PR DESCRIPTION
First, thanks for a great project!

My main branch that I want gitlab to compare everything to is `dev`, but my branch that pages is built from is `prod`. I don't think this is too uncommon.

This pull request adds support to upload the challenge files to a branch other than the "main" specified by Gitlab