### PR TITLE
make polling try every 30s for 15m

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -11,8 +11,8 @@ const { URL } = require('url');
 
 const generateRsa = () => RSA.generateKeypairAsync(2048, 65537, {});
 
-const pollUntilDeployed = (url, expectedContent, timeoutMs = 30 * 1000, retries = 10) => {
-    if (retries > 0) {
+const pollUntilDeployed = (url, expectedContent, timeoutMs = 30 * 1000, attempts = 30) => {
+    if (attempts > 0) {
         return request.get({
             url: url,
             simple: false // don't reject on 404
@@ -23,7 +23,7 @@ const pollUntilDeployed = (url, expectedContent, timeoutMs = 30 * 1000, retries 
                 // GitLab CI usually takes 50-80 seconds to build
                 console.log(`Could not find challenge file. Retrying in ${ms(timeoutMs)}...`);
                 return Promise.delay(timeoutMs).then(() =>
-                    pollUntilDeployed(url, expectedContent, timeoutMs * 2, retries - 1));
+                    pollUntilDeployed(url, expectedContent, timeoutMs, attempts - 1));
             }
         });
     } else {


### PR DESCRIPTION
I thought the graceful back-down times code was really clever - to double the time to poll for the challenge. I'm definitely going to use the method in other places.

Unfortunately, it doesn't quite 'click' here - to double it and retry 9 times, making 10 attempts in total, means that the biggest gap you can have is the last one - 256 minutes waiting. If all fail, then you've spent 511.5 minutes waiting, around 8.5 hours. On GitLab.com's free tier, that's over 1/4 of the allocated minutes you have per month, meaning that if the process fails 4 times, you've already destroyed all your allowed build time for the next month, for _all_ of your projects, not just this one.

Further, there are reports online that the nonces might even expire after around 10 minutes (although I haven't looked into this nor am I an expert). Which means even after 8 hours of build time, if the challenge finally uploaded, it wouldn't even work.

One thing we do know is that polling is cheap - it's just a basic http request so we don't need to worry about doing it too much.

This pull request addresses the above issues by doing the polling every 30s for 15 minutes, and then stopping. 15 minutes was chosen because it was a little more than the reported 10 minute expiry of the nonce, and I feel that if a site has longer than a 15 minute build time, there is probably a whole lot more going on there that they probably aren't hosting it on GitLab's free pages, but writing their own methods in-house.